### PR TITLE
feat: add pets CRUD endpoints

### DIFF
--- a/server/app/routers/pets.py
+++ b/server/app/routers/pets.py
@@ -1,9 +1,61 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
 
 router = APIRouter()
 
 
-@router.get("/pets")
-def list_pets() -> list[dict]:
+class PetCreate(BaseModel):
+    """Input model for creating a pet."""
+
+    name: str
+    age: int
+
+
+class Pet(PetCreate):
+    """Representation of a pet resource."""
+
+    id: int
+
+
+_PETS: dict[int, Pet] = {}
+_NEXT_ID = 1
+
+
+def _reset_state() -> None:
+    """Reset the in-memory store. Intended for tests."""
+
+    global _NEXT_ID
+    _PETS.clear()
+    _NEXT_ID = 1
+
+
+@router.get("/pets", response_model=list[Pet])
+def list_pets() -> list[Pet]:
     """Return the collection of pets."""
-    return []
+
+    return list(_PETS.values())
+
+
+@router.post("/pets", response_model=Pet, status_code=status.HTTP_201_CREATED)
+def create_pet(pet: PetCreate) -> Pet:
+    """Create a new pet entry."""
+
+    global _NEXT_ID
+    pet_id = _NEXT_ID
+    _NEXT_ID += 1
+
+    new_pet = Pet(id=pet_id, **pet.model_dump())
+    _PETS[pet_id] = new_pet
+    return new_pet
+
+
+@router.get("/pets/{pet_id}", response_model=Pet)
+def get_pet(pet_id: int) -> Pet:
+    """Retrieve a pet by its identifier."""
+
+    try:
+        return _PETS[pet_id]
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Pet not found"
+        ) from exc

--- a/server/tests/test_pets.py
+++ b/server/tests/test_pets.py
@@ -1,10 +1,51 @@
+import pytest
 from app.main import app
+from app.routers import pets as pets_router
 from fastapi.testclient import TestClient
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_pets_state() -> None:
+    """Ensure the in-memory store starts empty for each test."""
+
+    pets_router._reset_state()
+    yield
+    pets_router._reset_state()
 
 
 def test_pets_endpoint_returns_empty_list() -> None:
     response = client.get("/pets")
     assert response.status_code == 200
     assert response.json() == []
+
+
+def test_create_pet_returns_created_pet_and_updates_list() -> None:
+    payload = {"name": "Fido", "age": 4}
+    response = client.post("/pets", json=payload)
+
+    assert response.status_code == 201
+    created_pet = response.json()
+    assert created_pet["id"] == 1
+    assert created_pet["name"] == payload["name"]
+    assert created_pet["age"] == payload["age"]
+
+    list_response = client.get("/pets")
+    assert list_response.status_code == 200
+    assert list_response.json() == [created_pet]
+
+
+def test_get_pet_by_id_returns_existing_pet() -> None:
+    creation = client.post("/pets", json={"name": "Milo", "age": 2})
+    pet_id = creation.json()["id"]
+
+    response = client.get(f"/pets/{pet_id}")
+    assert response.status_code == 200
+    assert response.json() == creation.json()
+
+
+def test_get_pet_by_id_returns_404_for_missing_pet() -> None:
+    response = client.get("/pets/999")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Pet not found"}


### PR DESCRIPTION
## Summary
- implement in-memory storage to support listing, creating, and fetching pets
- add API tests covering the new endpoints and not-found behaviour

## Testing
- pytest -q

## DoD
- [x] CI 绿

------
https://chatgpt.com/codex/tasks/task_e_68ca7afa61508331a10e8aee153668ab